### PR TITLE
change type of logerrors in pg_exttable from char to boolean

### DIFF
--- a/gpcontrib/gp_exttable_fdw/gp_exttable_fdw--1.0.sql
+++ b/gpcontrib/gp_exttable_fdw/gp_exttable_fdw--1.0.sql
@@ -29,7 +29,7 @@ CREATE FUNCTION pg_exttable(OUT reloid oid,
                             OUT command text,
                             OUT rejectlimit int4,
                             OUT rejectlimittype "char",
-                            OUT logerrors "char",
+                            OUT logerrors bool,
                             OUT encoding int4,
                             OUT writable bool)
 RETURNS SETOF record

--- a/gpcontrib/gp_exttable_fdw/gp_exttable_fdw.c
+++ b/gpcontrib/gp_exttable_fdw/gp_exttable_fdw.c
@@ -231,7 +231,7 @@ Datum pg_exttable(PG_FUNCTION_ARGS)
 		TupleDescInitEntry(tupdesc, (AttrNumber) 7, "command", TEXTOID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 8, "rejectlimit", INT4OID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 9, "rejectlimittype", CHAROID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 10, "logerrors", CHAROID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 10, "logerrors", BOOLOID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 11, "encoding", INT4OID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 12, "writable", BOOLOID, -1, 0);
 
@@ -344,8 +344,15 @@ Datum pg_exttable(PG_FUNCTION_ARGS)
 			nulls[8] = true;
 
 		/* logerrors */
-		values[9] = CharGetDatum(extentry->logerrors);
-
+		if IS_LOG_TO_FILE(extentry->logerrors)
+		{
+			values[9] = BoolGetDatum(true);
+		}
+		else
+		{
+			values[9] = BoolGetDatum(false);
+		}
+		
 		/* encoding */
 		values[10] = Int32GetDatum(extentry->encoding);
 

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -3621,3 +3621,24 @@ INSERT INTO part_root SELECT i,i FROM generate_series(1,19)i;
 ALTER TABLE part_root SET DISTRIBUTED BY (b);
 
 DROP TABLE part_root;
+
+-- check logerrors value of pg_exttable
+CREATE EXTERNAL TABLE ext_false (c INT) 
+location ('file://@hostname@@abs_srcdir@/data/ext_fasle.tbl' )
+FORMAT 'text' (delimiter '|');
+CREATE EXTERNAL TABLE ext_true (c INT) 
+location ('file://@hostname@@abs_srcdir@/data/ext_true.tbl' )
+FORMAT 'text' (delimiter '|') LOG ERRORS SEGMENT REJECT LIMIT 100;
+CREATE EXTERNAL TABLE ext_persistently (c INT) 
+location ('file://@hostname@@abs_srcdir@/data/ext_persistently.tbl' )
+FORMAT 'text' (delimiter '|') LOG ERRORS PERSISTENTLY SEGMENT REJECT LIMIT 100;
+
+SELECT logerrors from pg_exttable a, pg_class b where a.reloid = b.oid and b.relname = 'ext_false';
+SELECT logerrors from pg_exttable a, pg_class b where a.reloid = b.oid and b.relname = 'ext_true';
+SELECT logerrors from pg_exttable a, pg_class b where a.reloid = b.oid and b.relname = 'ext_persistently';
+
+-- drop tables
+DROP EXTERNAL TABLE ext_false;
+DROP EXTERNAL TABLE ext_true;
+DROP EXTERNAL TABLE ext_persistently;
+

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -4926,3 +4926,35 @@ INSERT INTO part_root SELECT i,i FROM generate_series(1,19)i;
 ALTER TABLE part_root SET DISTRIBUTED BY (b);
 ERROR:  "part_ext_w" is not a table
 DROP TABLE part_root;
+-- check logerrors value of pg_exttable
+CREATE EXTERNAL TABLE ext_false (c INT) 
+location ('file://@hostname@@abs_srcdir@/data/ext_fasle.tbl' )
+FORMAT 'text' (delimiter '|');
+CREATE EXTERNAL TABLE ext_true (c INT) 
+location ('file://@hostname@@abs_srcdir@/data/ext_true.tbl' )
+FORMAT 'text' (delimiter '|') LOG ERRORS SEGMENT REJECT LIMIT 100;
+CREATE EXTERNAL TABLE ext_persistently (c INT) 
+location ('file://@hostname@@abs_srcdir@/data/ext_persistently.tbl' )
+FORMAT 'text' (delimiter '|') LOG ERRORS PERSISTENTLY SEGMENT REJECT LIMIT 100;
+SELECT logerrors from pg_exttable a, pg_class b where a.reloid = b.oid and b.relname = 'ext_false';
+ logerrors 
+-----------
+ f
+(1 row)
+
+SELECT logerrors from pg_exttable a, pg_class b where a.reloid = b.oid and b.relname = 'ext_true';
+ logerrors 
+-----------
+ t
+(1 row)
+
+SELECT logerrors from pg_exttable a, pg_class b where a.reloid = b.oid and b.relname = 'ext_persistently';
+ logerrors 
+-----------
+ t
+(1 row)
+
+-- drop tables
+DROP EXTERNAL TABLE ext_false;
+DROP EXTERNAL TABLE ext_true;
+DROP EXTERNAL TABLE ext_persistently;


### PR DESCRIPTION
pg_exttable on gpdb7 is not consistent with gpdb6
 
This is the result of `\d pg_exttable` in gpdb6:
```
[gpadmin@localhost ~]$ psql
psql (9.4.26)
Type "help" for help.
  
gpadmin=# \d pg_exttable
    Table "pg_catalog.pg_exttable"
     Column      |  Type   | Modifiers
-----------------+---------+-----------
 reloid          | oid     | not null
 urilocation     | text[]  |
 execlocation    | text[]  |
 fmttype         | "char"  |
 fmtopts         | text    |
 options         | text[]  |
 command         | text    |
 rejectlimit     | integer |
 rejectlimittype | "char"  |
 logerrors       | boolean |
 encoding        | integer |
 writable        | boolean |
Indexes:
    "pg_exttable_reloid_index" UNIQUE, btree (reloid)
```
This is the result of `\d pg_exttable` in gpdb7:
```
[gpadmin@localhost ~]$ psql
psql (12beta2)
Type "help" for help.
  
gpadmin=# \d pg_exttable
               View "pg_catalog.pg_exttable"
     Column      |  Type   | Collation | Nullable | Default
-----------------+---------+-----------+----------+---------
 reloid          | oid     |           |          |
 urilocation     | text[]  |           |          |
 execlocation    | text[]  |           |          |
 fmttype         | "char"  |           |          |
 fmtopts         | text    |           |          |
 options         | text[]  |           |          |
 command         | text    |           |          |
 rejectlimit     | integer |           |          |
 rejectlimittype | "char"  |           |          |
 logerrors       | "char"  |           |          |
 encoding        | integer |           |          |
 writable        | boolean |           |          |
```
The type of logerrors is **boolean** and **char** in gpdb6 and gpdb7, respectively.
As best I know, there are 2 reasons we need this change:

- for easier backup & restore between different versions
- some GUI faces error because `pg_exttable` on gpdb7 is not consistent with gpdb6

We want that pg_exttable result in gpdb7 should be consistent with gpdb6, the type of logerrors should be revised.
BTW, this pr still dosen't affetct the normal funciton of `LOG_ERRORS_PERSISTENTLY`, only the display result has been changed. Take a example as followed:
```
SELECT logerrors from pg_exttable a, pg_class b where a.reloid = b.oid and b.relname = 'ext_persistently';
 logerrors 
-----------
 t
(1 row)
```
the pg_foreign_table still keeps the info `log_errors=p`:
```
gpadmin=# select * from pg_catalog.pg_foreign_table;
 ftrelid | ftserver | ftoptions
 16403 |    13212 | {format=text,delimiter=|,"null=\\N","escape=\\",format_type=t,location_uris=file://
@hostname@@abs_srcdir@/data/ext_persistently.tbl,execute_on=ALL_SEGMENTS,reject_limit=100,reject_limit_ty
pe=r,log_errors=p,encoding=6,is_writable=false}
```