### PR TITLE
CDC send data to kafka

### DIFF
--- a/contrib/test_decoding/Makefile
+++ b/contrib/test_decoding/Makefile
@@ -1,5 +1,4 @@
 # contrib/test_decoding/Makefile
-
 MODULES = test_decoding
 PGFILEDESC = "test_decoding - example of a logical decoding output plugin"
 
@@ -26,6 +25,8 @@ top_builddir = ../..
 include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
 endif
+
+LDFLAGS += -lrdkafka
 
 # But it can nonetheless be very helpful to run tests on preexisting
 # installation, allow to do so, but only if requested explicitly.

--- a/src/bin/psql/common.c
+++ b/src/bin/psql/common.c
@@ -496,6 +496,7 @@ AcceptResult(const PGresult *result)
 			case PGRES_EMPTY_QUERY:
 			case PGRES_COPY_IN:
 			case PGRES_COPY_OUT:
+			case PGRES_COPY_BOTH:
 				/* Fine, do nothing */
 				OK = true;
 				break;
@@ -1054,6 +1055,7 @@ ProcessResult(PGresult **results)
 
 			case PGRES_COPY_OUT:
 			case PGRES_COPY_IN:
+			case PGRES_COPY_BOTH:
 				is_copy = true;
 				break;
 
@@ -1265,6 +1267,7 @@ PrintQueryResults(PGresult *results)
 
 		case PGRES_COPY_OUT:
 		case PGRES_COPY_IN:
+		case PGRES_COPY_BOTH:
 			/* nothing to do here */
 			success = true;
 			break;


### PR DESCRIPTION
Change data capture is a new feature of GPDB7.
The data routine is gpdb -> logical decoding -> kafka -> remote gpdb.
This pr is the for the fisrt step, from gpdb to kafka. 

Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>